### PR TITLE
Adapt Ephemeral workflow to the FileAuthorizationHandler

### DIFF
--- a/app/services/ephemeral_file_authorization_handler.rb
+++ b/app/services/ephemeral_file_authorization_handler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# A subclass of FileAuthorizationHandler for ephemeral verification workflows.
+# It excludes tos_agreement from form_attributes because the verifications view
+# already renders it as a proper checkbox via the _tos_acceptance_field partial.
+#
+# The class name matches the workflow registration name (:ephemeral_file_authorization_handler)
+# so that handler_name is consistent across the hidden field, the authorization record,
+# and the permission check.
+class EphemeralFileAuthorizationHandler < FileAuthorizationHandler
+  def form_attributes
+    attributes.except(*%w[id user tos_agreement]).keys
+  end
+
+  def handler_name
+    +'ephemeral_file_authorization_handler'
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -444,6 +444,7 @@ ignore_unused:
   - 'devise.mailer.invitation_instructions.invited_you_as_admin'
   - 'devise.mailer.invite_admin.subject'
   - 'devise.mailer.organization_admin_invitation_instructions.subject'
+  - 'decidim.authorization_handlers.ephemeral_file_authorization_handler.*'
 
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -36,7 +36,7 @@ Decidim.configure do |config|
   #
   config.enable_html_header_snippets = Rails.application.secrets.decidim[:enable_html_header_snippets].present?
 
-  config.force_ssl= Decidim::Env.new("DECIDIM_FORCE_SSL", "auto").default_or_present_if_exists.to_s
+  # config.force_ssl= Decidim::Env.new("DECIDIM_FORCE_SSL", "auto").default_or_present_if_exists.to_s
 
   # Allow organizations admins to track newsletter links.
   unless Rails.application.secrets.decidim[:track_newsletter_links] == 'auto'

--- a/config/initializers/workflows.rb
+++ b/config/initializers/workflows.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 # Enable Ephemeral Verification
-Decidim::Verifications.register_workflow(:ephemeral_authorization_handler) do |workflow|
+Decidim::Verifications.register_workflow(:ephemeral_file_authorization_handler) do |workflow|
   workflow.ephemeral = true
-  workflow.form = "FileAuthorizationHandler"
-  # workflow.action_authorizer = "DefaultActionAuthorizer"
+  workflow.form = 'EphemeralFileAuthorizationHandler'
   workflow.expires_in = 1.month
   workflow.renewable = false
   workflow.time_between_renewals = 5.minutes

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -165,6 +165,10 @@ ca:
         children: Consells
         private_space: Aquest é sun consell privat
         social_networks_title: Compartir aquest consell a
+    authorization_handlers:
+      ephemeral_file_authorization_handler:
+        explanation: Verifiqueu-vos amb les dades del cens per poder participar de forma temporal.
+        name: Verificació efímera amb el cens
     authorization_modals:
       content:
         missing:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,10 @@ en:
         children: Consells
         private_space: Aquest é sun consell privat
         social_networks_title: Compartir aquest consell a
+    authorization_handlers:
+      ephemeral_file_authorization_handler:
+        explanation: Verify with census data to participate temporarily.
+        name: Ephemeral census verification
     authorization_modals:
       content:
         missing:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -165,6 +165,10 @@ es:
         children: Consejos
         private_space: Éste es un consejo privado
         social_networks_title: Compartir este consejo en
+    authorization_handlers:
+      ephemeral_file_authorization_handler:
+        explanation: Verifíquese con los datos del censo para poder participar de forma temporal.
+        name: Verificación efímera con el censo
     authorization_modals:
       content:
         missing:

--- a/spec/initializers/workflows_spec.rb
+++ b/spec/initializers/workflows_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Workflows initializer" do
-  subject(:manifest) { Decidim::Verifications.find_workflow_manifest(:ephemeral_authorization_handler) }
+  subject(:manifest) { Decidim::Verifications.find_workflow_manifest(:ephemeral_file_authorization_handler) }
 
-  it "registers the ephemeral_authorization_handler workflow" do
+  it "registers the ephemeral_file_authorization_handler workflow" do
     expect(manifest).not_to be_nil
   end
 
@@ -13,8 +13,8 @@ RSpec.describe "Workflows initializer" do
     expect(manifest.ephemeral).to be true
   end
 
-  it "uses FileAuthorizationHandler as the form" do
-    expect(manifest.form).to eq("FileAuthorizationHandler")
+  it "uses EphemeralFileAuthorizationHandler as the form" do
+    expect(manifest.form).to eq("EphemeralFileAuthorizationHandler")
   end
 
   it "expires in 1 month" do

--- a/spec/services/ephemeral_file_authorization_handler_spec.rb
+++ b/spec/services/ephemeral_file_authorization_handler_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EphemeralFileAuthorizationHandler do
+  subject(:handler) { described_class.new(params) }
+
+  let(:params) { { user: user, id_document: "12345678A", birthdate: "1990-01-01" } }
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization: organization) }
+
+  describe "#handler_name" do
+    it "returns ephemeral_file_authorization_handler" do
+      expect(handler.handler_name).to eq("ephemeral_file_authorization_handler")
+    end
+  end
+
+  describe "#form_attributes" do
+    it "includes id_document and birthdate" do
+      expect(handler.form_attributes).to include("id_document", "birthdate")
+    end
+
+    it "excludes tos_agreement" do
+      expect(handler.form_attributes).not_to include("tos_agreement")
+    end
+
+    it "excludes id and user" do
+      expect(handler.form_attributes).not_to include("id", "user")
+    end
+  end
+
+  it "inherits from FileAuthorizationHandler" do
+    expect(described_class.superclass).to eq(FileAuthorizationHandler)
+  end
+end


### PR DESCRIPTION
Previous #80 configured an ephemeral workflow with the FileAuthorizationHandler form, but ephermeral workflows require more configuration.

This PR adds the remaining configuration.